### PR TITLE
Added detection for old NFT contracts such as CryptoKitties and CryptoPunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,7 @@
 ### 1.5.1 (2022-04-08)
 
 * `analyzeTransaction()` returns the contract address paramater for contract-interaction transaction.
+
+### 1.6.1 (2022-04-18)
+
+* `analyzeTransaction()` also detects the NFTs which uses the deprecated erc721 contract standard. Supported old NFT contracts include [CryptoKitties](https://etherscan.io/address/0x06012c8cf97BEaD5deAe237070F9587f8E7A266d) and [CryptoPunks](https://etherscan.io/address/0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsafle/transaction-controller",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -240,9 +240,9 @@
       }
     },
     "@getsafle/safle-identity-wallet": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@getsafle/safle-identity-wallet/-/safle-identity-wallet-1.2.1.tgz",
-      "integrity": "sha512-+Pk71EoI72IZ95iCCIo4HdabO3NbCjBoAPiBf9UZ5yca4dkcKRgoLqVw6D+39r8SM9lkEJP0ps0WrbBJ9bf/cA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@getsafle/safle-identity-wallet/-/safle-identity-wallet-1.2.2.tgz",
+      "integrity": "sha512-F8JKOIvMdOxhfH9wHHKTSgA3EgTC2T6VcKZwivCk0zAp94oDlgbj1ZZykTXm4MnzLf1fkDzF+AfdfnsfXQ8bIA==",
       "requires": {
         "ethereumjs-tx": "^2.1.2",
         "web3": "^1.2.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsafle/transaction-controller",
-  "version": "1.5.1",
+  "version": "1.6.1",
   "description": "Getsafle transaction controller",
   "main": "src/index.js",
   "scripts": {
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/getsafle/transaction-controller#readme",
   "dependencies": {
     "@getsafle/custom-token-controller": "^1.0.3",
-    "@getsafle/safle-identity-wallet": "^1.2.1",
+    "@getsafle/safle-identity-wallet": "^1.2.2",
     "abi-decoder": "^2.4.0",
     "axios": "^0.21.1",
     "web3": "^1.7.1"

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -7,7 +7,8 @@ const swap2 = require('./swap2');
 const burn = require('./burn');
 const mint = require('./mint');
 const erc721Approval = require('./approval-erc721');
-const erc721Transfer = require('./transfer-erc721');
+const erc721Transfer_1 = require('./transfer-erc721-1');
+const erc721Transfer_2 = require('./transfer-erc721-2');
 
 abiDecoder.addABI(transfer);
 abiDecoder.addABI(approval);
@@ -16,4 +17,4 @@ abiDecoder.addABI(swap2);
 abiDecoder.addABI(burn);
 abiDecoder.addABI(mint);
 
-module.exports = { abiDecoder, erc721Approval, erc721Transfer };
+module.exports = { abiDecoder, erc721Approval, erc721Transfer_1, erc721Transfer_2 };

--- a/src/events/transfer-erc721-1.js
+++ b/src/events/transfer-erc721-1.js
@@ -1,0 +1,29 @@
+const TransferEvent = [
+    {
+        "anonymous":false,
+        "inputs": [
+            {
+                "indexed":false,
+                "internalType":"address",
+                "name":"from",
+                "type":"address"
+            },
+            {
+                "indexed":false,
+                "internalType":"address",
+                "name":"to",
+                "type":"address"
+            },
+            {
+                "indexed":false,
+                "internalType":"uint256",
+                "name":"tokenId",
+                "type":"uint256"
+            }
+        ],
+        "name":"Transfer",
+        "type":"event"
+    }
+]
+
+module.exports = TransferEvent;

--- a/src/events/transfer-erc721-2.js
+++ b/src/events/transfer-erc721-2.js
@@ -3,21 +3,21 @@ const TransferEvent = [
         "anonymous":false,
         "inputs": [
             {
-                "indexed":true,
+                "indexed":false,
                 "internalType":"address",
-                "name":"from",
+                "name":"_from",
                 "type":"address"
             },
             {
-                "indexed":true,
+                "indexed":false,
                 "internalType":"address",
-                "name":"to",
+                "name":"_to",
                 "type":"address"
             },
             {
-                "indexed":true,
+                "indexed":false,
                 "internalType":"uint256",
-                "name":"tokenId",
+                "name":"_tokenId",
                 "type":"uint256"
             }
         ],

--- a/src/function-abis/crypto-kitties.js
+++ b/src/function-abis/crypto-kitties.js
@@ -1,0 +1,1106 @@
+const CryptoKitties = [
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '_interfaceID',
+        type: 'bytes4',
+      },
+    ],
+    name: 'supportsInterface',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'cfoAddress',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '_tokenId',
+        type: 'uint256',
+      },
+      {
+        name: '_preferredTransport',
+        type: 'string',
+      },
+    ],
+    name: 'tokenMetadata',
+    outputs: [
+      {
+        name: 'infoUrl',
+        type: 'string',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'promoCreatedCount',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'name',
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_to',
+        type: 'address',
+      },
+      {
+        name: '_tokenId',
+        type: 'uint256',
+      },
+    ],
+    name: 'approve',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'ceoAddress',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'GEN0_STARTING_PRICE',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_address',
+        type: 'address',
+      },
+    ],
+    name: 'setSiringAuctionAddress',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'pregnantKitties',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '_kittyId',
+        type: 'uint256',
+      },
+    ],
+    name: 'isPregnant',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'GEN0_AUCTION_DURATION',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'siringAuction',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_from',
+        type: 'address',
+      },
+      {
+        name: '_to',
+        type: 'address',
+      },
+      {
+        name: '_tokenId',
+        type: 'uint256',
+      },
+    ],
+    name: 'transferFrom',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_address',
+        type: 'address',
+      },
+    ],
+    name: 'setGeneScienceAddress',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_newCEO',
+        type: 'address',
+      },
+    ],
+    name: 'setCEO',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_newCOO',
+        type: 'address',
+      },
+    ],
+    name: 'setCOO',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_kittyId',
+        type: 'uint256',
+      },
+      {
+        name: '_startingPrice',
+        type: 'uint256',
+      },
+      {
+        name: '_endingPrice',
+        type: 'uint256',
+      },
+      {
+        name: '_duration',
+        type: 'uint256',
+      },
+    ],
+    name: 'createSaleAuction',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [],
+    name: 'unpause',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    name: 'sireAllowedToAddress',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '_matronId',
+        type: 'uint256',
+      },
+      {
+        name: '_sireId',
+        type: 'uint256',
+      },
+    ],
+    name: 'canBreedWith',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    name: 'kittyIndexToApproved',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_kittyId',
+        type: 'uint256',
+      },
+      {
+        name: '_startingPrice',
+        type: 'uint256',
+      },
+      {
+        name: '_endingPrice',
+        type: 'uint256',
+      },
+      {
+        name: '_duration',
+        type: 'uint256',
+      },
+    ],
+    name: 'createSiringAuction',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'val',
+        type: 'uint256',
+      },
+    ],
+    name: 'setAutoBirthFee',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_addr',
+        type: 'address',
+      },
+      {
+        name: '_sireId',
+        type: 'uint256',
+      },
+    ],
+    name: 'approveSiring',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_newCFO',
+        type: 'address',
+      },
+    ],
+    name: 'setCFO',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_genes',
+        type: 'uint256',
+      },
+      {
+        name: '_owner',
+        type: 'address',
+      },
+    ],
+    name: 'createPromoKitty',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'secs',
+        type: 'uint256',
+      },
+    ],
+    name: 'setSecondsPerBlock',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'paused',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [],
+    name: 'withdrawBalance',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '_tokenId',
+        type: 'uint256',
+      },
+    ],
+    name: 'ownerOf',
+    outputs: [
+      {
+        name: 'owner',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'GEN0_CREATION_LIMIT',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'newContractAddress',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_address',
+        type: 'address',
+      },
+    ],
+    name: 'setSaleAuctionAddress',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '_owner',
+        type: 'address',
+      },
+    ],
+    name: 'balanceOf',
+    outputs: [
+      {
+        name: 'count',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_v2Address',
+        type: 'address',
+      },
+    ],
+    name: 'setNewAddress',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'secondsPerBlock',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [],
+    name: 'pause',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '_owner',
+        type: 'address',
+      },
+    ],
+    name: 'tokensOfOwner',
+    outputs: [
+      {
+        name: 'ownerTokens',
+        type: 'uint256[]',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_matronId',
+        type: 'uint256',
+      },
+    ],
+    name: 'giveBirth',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [],
+    name: 'withdrawAuctionBalances',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'symbol',
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    name: 'cooldowns',
+    outputs: [
+      {
+        name: '',
+        type: 'uint32',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    name: 'kittyIndexToOwner',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_to',
+        type: 'address',
+      },
+      {
+        name: '_tokenId',
+        type: 'uint256',
+      },
+    ],
+    name: 'transfer',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'cooAddress',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'autoBirthFee',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'erc721Metadata',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_genes',
+        type: 'uint256',
+      },
+    ],
+    name: 'createGen0Auction',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '_kittyId',
+        type: 'uint256',
+      },
+    ],
+    name: 'isReadyToBreed',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'PROMO_CREATION_LIMIT',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_contractAddress',
+        type: 'address',
+      },
+    ],
+    name: 'setMetadataAddress',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'saleAuction',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '_id',
+        type: 'uint256',
+      },
+    ],
+    name: 'getKitty',
+    outputs: [
+      {
+        name: 'isGestating',
+        type: 'bool',
+      },
+      {
+        name: 'isReady',
+        type: 'bool',
+      },
+      {
+        name: 'cooldownIndex',
+        type: 'uint256',
+      },
+      {
+        name: 'nextActionAt',
+        type: 'uint256',
+      },
+      {
+        name: 'siringWithId',
+        type: 'uint256',
+      },
+      {
+        name: 'birthTime',
+        type: 'uint256',
+      },
+      {
+        name: 'matronId',
+        type: 'uint256',
+      },
+      {
+        name: 'sireId',
+        type: 'uint256',
+      },
+      {
+        name: 'generation',
+        type: 'uint256',
+      },
+      {
+        name: 'genes',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_sireId',
+        type: 'uint256',
+      },
+      {
+        name: '_matronId',
+        type: 'uint256',
+      },
+    ],
+    name: 'bidOnSiringAuction',
+    outputs: [],
+    payable: true,
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'gen0CreatedCount',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'geneScience',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: '_matronId',
+        type: 'uint256',
+      },
+      {
+        name: '_sireId',
+        type: 'uint256',
+      },
+    ],
+    name: 'breedWithAuto',
+    outputs: [],
+    payable: true,
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    payable: true,
+    stateMutability: 'payable',
+    type: 'fallback',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'matronId',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'sireId',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'cooldownEndBlock',
+        type: 'uint256',
+      },
+    ],
+    name: 'Pregnant',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'tokenId',
+        type: 'uint256',
+      },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'approved',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'tokenId',
+        type: 'uint256',
+      },
+    ],
+    name: 'Approval',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'kittyId',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'matronId',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'sireId',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'genes',
+        type: 'uint256',
+      },
+    ],
+    name: 'Birth',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        name: 'newContract',
+        type: 'address',
+      },
+    ],
+    name: 'ContractUpgrade',
+    type: 'event',
+  },
+]
+
+module.exports = CryptoKitties

--- a/src/function-abis/crypto-punks.js
+++ b/src/function-abis/crypto-punks.js
@@ -1,0 +1,456 @@
+const CryptoPunks = [{
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [{
+        "name": "",
+        "type": "string"
+    }],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [{
+        "name": "",
+        "type": "uint256"
+    }],
+    "name": "punksOfferedForSale",
+    "outputs": [{
+        "name": "isForSale",
+        "type": "bool"
+    }, {
+        "name": "punkIndex",
+        "type": "uint256"
+    }, {
+        "name": "seller",
+        "type": "address"
+    }, {
+        "name": "minValue",
+        "type": "uint256"
+    }, {
+        "name": "onlySellTo",
+        "type": "address"
+    }],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": false,
+    "inputs": [{
+        "name": "punkIndex",
+        "type": "uint256"
+    }],
+    "name": "enterBidForPunk",
+    "outputs": [],
+    "payable": true,
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{
+        "name": "",
+        "type": "uint256"
+    }],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": false,
+    "inputs": [{
+        "name": "punkIndex",
+        "type": "uint256"
+    }, {
+        "name": "minPrice",
+        "type": "uint256"
+    }],
+    "name": "acceptBidForPunk",
+    "outputs": [],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{
+        "name": "",
+        "type": "uint8"
+    }],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": false,
+    "inputs": [{
+        "name": "addresses",
+        "type": "address[]"
+    }, {
+        "name": "indices",
+        "type": "uint256[]"
+    }],
+    "name": "setInitialOwners",
+    "outputs": [],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": false,
+    "inputs": [],
+    "name": "withdraw",
+    "outputs": [],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [],
+    "name": "imageHash",
+    "outputs": [{
+        "name": "",
+        "type": "string"
+    }],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [],
+    "name": "nextPunkIndexToAssign",
+    "outputs": [{
+        "name": "",
+        "type": "uint256"
+    }],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [{
+        "name": "",
+        "type": "uint256"
+    }],
+    "name": "punkIndexToAddress",
+    "outputs": [{
+        "name": "",
+        "type": "address"
+    }],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [],
+    "name": "standard",
+    "outputs": [{
+        "name": "",
+        "type": "string"
+    }],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [{
+        "name": "",
+        "type": "uint256"
+    }],
+    "name": "punkBids",
+    "outputs": [{
+        "name": "hasBid",
+        "type": "bool"
+    }, {
+        "name": "punkIndex",
+        "type": "uint256"
+    }, {
+        "name": "bidder",
+        "type": "address"
+    }, {
+        "name": "value",
+        "type": "uint256"
+    }],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [{
+        "name": "",
+        "type": "address"
+    }],
+    "name": "balanceOf",
+    "outputs": [{
+        "name": "",
+        "type": "uint256"
+    }],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": false,
+    "inputs": [],
+    "name": "allInitialOwnersAssigned",
+    "outputs": [],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [],
+    "name": "allPunksAssigned",
+    "outputs": [{
+        "name": "",
+        "type": "bool"
+    }],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": false,
+    "inputs": [{
+        "name": "punkIndex",
+        "type": "uint256"
+    }],
+    "name": "buyPunk",
+    "outputs": [],
+    "payable": true,
+    "type": "function"
+}, {
+    "constant": false,
+    "inputs": [{
+        "name": "to",
+        "type": "address"
+    }, {
+        "name": "punkIndex",
+        "type": "uint256"
+    }],
+    "name": "transferPunk",
+    "outputs": [],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{
+        "name": "",
+        "type": "string"
+    }],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": false,
+    "inputs": [{
+        "name": "punkIndex",
+        "type": "uint256"
+    }],
+    "name": "withdrawBidForPunk",
+    "outputs": [],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": false,
+    "inputs": [{
+        "name": "to",
+        "type": "address"
+    }, {
+        "name": "punkIndex",
+        "type": "uint256"
+    }],
+    "name": "setInitialOwner",
+    "outputs": [],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": false,
+    "inputs": [{
+        "name": "punkIndex",
+        "type": "uint256"
+    }, {
+        "name": "minSalePriceInWei",
+        "type": "uint256"
+    }, {
+        "name": "toAddress",
+        "type": "address"
+    }],
+    "name": "offerPunkForSaleToAddress",
+    "outputs": [],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [],
+    "name": "punksRemainingToAssign",
+    "outputs": [{
+        "name": "",
+        "type": "uint256"
+    }],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": false,
+    "inputs": [{
+        "name": "punkIndex",
+        "type": "uint256"
+    }, {
+        "name": "minSalePriceInWei",
+        "type": "uint256"
+    }],
+    "name": "offerPunkForSale",
+    "outputs": [],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": false,
+    "inputs": [{
+        "name": "punkIndex",
+        "type": "uint256"
+    }],
+    "name": "getPunk",
+    "outputs": [],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": true,
+    "inputs": [{
+        "name": "",
+        "type": "address"
+    }],
+    "name": "pendingWithdrawals",
+    "outputs": [{
+        "name": "",
+        "type": "uint256"
+    }],
+    "payable": false,
+    "type": "function"
+}, {
+    "constant": false,
+    "inputs": [{
+        "name": "punkIndex",
+        "type": "uint256"
+    }],
+    "name": "punkNoLongerForSale",
+    "outputs": [],
+    "payable": false,
+    "type": "function"
+}, {
+    "inputs": [],
+    "payable": true,
+    "type": "constructor"
+}, {
+    "anonymous": false,
+    "inputs": [{
+        "indexed": true,
+        "name": "to",
+        "type": "address"
+    }, {
+        "indexed": false,
+        "name": "punkIndex",
+        "type": "uint256"
+    }],
+    "name": "Assign",
+    "type": "event"
+}, {
+    "anonymous": false,
+    "inputs": [{
+        "indexed": true,
+        "name": "from",
+        "type": "address"
+    }, {
+        "indexed": true,
+        "name": "to",
+        "type": "address"
+    }, {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+    }],
+    "name": "Transfer",
+    "type": "event"
+}, {
+    "anonymous": false,
+    "inputs": [{
+        "indexed": true,
+        "name": "from",
+        "type": "address"
+    }, {
+        "indexed": true,
+        "name": "to",
+        "type": "address"
+    }, {
+        "indexed": false,
+        "name": "punkIndex",
+        "type": "uint256"
+    }],
+    "name": "PunkTransfer",
+    "type": "event"
+}, {
+    "anonymous": false,
+    "inputs": [{
+        "indexed": true,
+        "name": "punkIndex",
+        "type": "uint256"
+    }, {
+        "indexed": false,
+        "name": "minValue",
+        "type": "uint256"
+    }, {
+        "indexed": true,
+        "name": "toAddress",
+        "type": "address"
+    }],
+    "name": "PunkOffered",
+    "type": "event"
+}, {
+    "anonymous": false,
+    "inputs": [{
+        "indexed": true,
+        "name": "punkIndex",
+        "type": "uint256"
+    }, {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+    }, {
+        "indexed": true,
+        "name": "fromAddress",
+        "type": "address"
+    }],
+    "name": "PunkBidEntered",
+    "type": "event"
+}, {
+    "anonymous": false,
+    "inputs": [{
+        "indexed": true,
+        "name": "punkIndex",
+        "type": "uint256"
+    }, {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+    }, {
+        "indexed": true,
+        "name": "fromAddress",
+        "type": "address"
+    }],
+    "name": "PunkBidWithdrawn",
+    "type": "event"
+}, {
+    "anonymous": false,
+    "inputs": [{
+        "indexed": true,
+        "name": "punkIndex",
+        "type": "uint256"
+    }, {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+    }, {
+        "indexed": true,
+        "name": "fromAddress",
+        "type": "address"
+    }, {
+        "indexed": true,
+        "name": "toAddress",
+        "type": "address"
+    }],
+    "name": "PunkBought",
+    "type": "event"
+}, {
+    "anonymous": false,
+    "inputs": [{
+        "indexed": true,
+        "name": "punkIndex",
+        "type": "uint256"
+    }],
+    "name": "PunkNoLongerForSale",
+    "type": "event"
+}]
+
+module.exports = CryptoPunks

--- a/src/function-abis/erc721.js
+++ b/src/function-abis/erc721.js
@@ -257,6 +257,39 @@ const ERC721ABI = [
 		"inputs": [
 			{
 				"internalType": "address",
+				"name": "_from",
+				"type": "address"
+			},
+			{
+				"internalType": "address",
+				"name": "_to",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "_id",
+				"type": "uint256"
+			},
+			{
+				"internalType": "uint256",
+				"name": "_value",
+				"type": "uint256"
+			},
+			{
+				"internalType": "bytes",
+				"name": "_data",
+				"type": "bytes"
+			}
+		],
+		"name": "safeTransferFrom",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
 				"name": "operator",
 				"type": "address"
 			},
@@ -341,6 +374,24 @@ const ERC721ABI = [
 			}
 		],
 		"name": "transferFrom",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "_to",
+				"type": "address"
+			},
+			{
+				"internalType": "uint256",
+				"name": "_tokenId",
+				"type": "uint256"
+			}
+		],
+		"name": "transfer",
 		"outputs": [],
 		"stateMutability": "nonpayable",
 		"type": "function"

--- a/src/function-abis/index.js
+++ b/src/function-abis/index.js
@@ -7,6 +7,8 @@ const swapABI6 = require('./swap-6');
 const transferABI = require('./transfer');
 const erc20ABI = require('./erc20');
 const erc721ABI = require('./erc721');
+const CryptoPunks = require('./crypto-punks');
+const CryptoKitties = require('./crypto-kitties');
 
 module.exports = {
     swapABI1,
@@ -18,4 +20,6 @@ module.exports = {
     transferABI,
     erc20ABI,
     erc721ABI,
+    CryptoPunks,
+    CryptoKitties,
 }

--- a/src/function-signatures/index.js
+++ b/src/function-signatures/index.js
@@ -24,6 +24,17 @@ const sig = {
     '0x8ba4cc3c': 'Airdrop',
     '0x23b872dd': 'Transfer From',
     '0x42842e0e': 'Safe Transfer From',
+    '0xf242432a': 'Safe Transfer From',
+    '0xa22cb465': 'Set Approval For All',
+    '0xab834bab': 'Atomic Match_',
+    '0x3f801f91': 'Proxy Assert',
+    '0x58fbdd0a': 'Buy And Swap721',
+    '0x0c53c51c': 'Execute Meta Transaction',
+    '0x8b72a2ec': 'Transfer Punk',
+    '0x8264fe98': 'Buy Punk',
+    '0xc44193c3': 'Offer Punk For Sale',
+    '0x091dbfd2': 'Enter Bid For Punk',
+    '0x23165b75': 'Accept Bid For Punk',
 }
 
 module.exports = sig;

--- a/src/index.js
+++ b/src/index.js
@@ -94,11 +94,13 @@ class TransactionController {
 
       logs = await Helper.extractNFTLogs(transactionHash, web3);
 
-      const nftTransferDetails = await Helper.extractNFTTransferDetails(input, functionName);
+      if (functionName.includes('Transfer')) {
+        const nftTransferDetails = await Helper.extractNFTTransferDetails(input, functionName, to, from, web3);
 
-      id = await safleId.getSafleId(nftTransferDetails.recepient);
-
-      txParams = nftTransferDetails;
+        txParams = nftTransferDetails;
+        
+        id = await safleId.getSafleId(nftTransferDetails.recepient);
+      }
 
     } else {
       logs = await Helper.extractLogs(transactionHash, web3);

--- a/src/utils/old-nft-contracts.js
+++ b/src/utils/old-nft-contracts.js
@@ -1,0 +1,6 @@
+const oldNFTContract = {
+    '0x06012c8cf97BEaD5deAe237070F9587f8E7A266d': 'CryptoKitties',
+    '0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB': 'CryptoPunks',
+}
+
+module.exports = oldNFTContract;


### PR DESCRIPTION
Added support for NFTs which uses the deprecated erc721 contract standard.

Supported old NFT contracts include :
- [CryptoKitties](https://etherscan.io/address/0x06012c8cf97BEaD5deAe237070F9587f8E7A266d)
- [CryptoPunks](https://etherscan.io/address/0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB)